### PR TITLE
Add S3 bucket prefix when not blank or starting with the same prefix

### DIFF
--- a/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3Fetcher.java
+++ b/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3Fetcher.java
@@ -79,7 +79,12 @@ public class S3Fetcher implements Fetcher {
             if (org.apache.commons.lang3.StringUtils.isNotBlank(prefix) && !prefix.endsWith("/")) {
                 prefix += "/";
             }
-            String theFetchKey = StringUtils.isBlank(prefix) ? fetchKey : prefix + fetchKey;
+            String theFetchKey;
+            if (StringUtils.isBlank(prefix) || fetchKey.startsWith(prefix)) {
+                theFetchKey = fetchKey;
+            } else {
+                theFetchKey = prefix + fetchKey;
+            }
             try {
                 long start = System.currentTimeMillis();
                 InputStream is = _fetch(s3Client, s3FetcherConfig, theFetchKey, fetchMetadata, responseMetadata);


### PR DESCRIPTION
Reduces potential user error where the fetch key includes the prefix (which can be set in fetcher configuration)