### PR TITLE
Abort S3 ResponseInputStream when catching exception

### DIFF
--- a/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3Fetcher.java
+++ b/tika-pipes-fetchers/tika-fetcher-s3/src/main/java/org/apache/tika/pipes/fetchers/s3/S3Fetcher.java
@@ -128,6 +128,7 @@ public class S3Fetcher implements Fetcher {
         Long startRange = (Long) fetchMetadata.get("startRange");
         Long endRange = (Long) fetchMetadata.get("endRange");
         TemporaryResources tmp = null;
+        ResponseInputStream<GetObjectResponse> s3Object = null;
         String bucket = s3FetcherConfig.getBucket();
         try {
             long start = System.currentTimeMillis();
@@ -139,7 +140,7 @@ public class S3Fetcher implements Fetcher {
             }
             GetObjectRequest objectRequest = builder
                     .build();
-            ResponseInputStream<GetObjectResponse> s3Object = s3Client.getObject(objectRequest);
+            s3Object = s3Client.getObject(objectRequest);
             long length = s3Object.response()
                     .contentLength();
             responseMetadata.put(Metadata.CONTENT_LENGTH, Long.toString(length));
@@ -171,6 +172,10 @@ public class S3Fetcher implements Fetcher {
                 return tis;
             }
         } catch (Throwable e) {
+            if (s3Object != null) {
+                log.info("Aborting S3 object stream due to exception");
+                s3Object.abort();
+            }
             if (tmp != null) {
                 tmp.close();
             }


### PR DESCRIPTION
It is my understanding that we may be unnecessarily holding onto the s3Object in memory in the case of an exception thrown (eg FileTooLongException)

Two notes from the AWS SDK docs which suggest `abort()` is the right move:

> A ResponseInputStream containing data streamed from service. Note that this is an unmanaged reference to the underlying HTTP connection so great care must be taken to ensure all data if fully read from the input stream and that it is properly closed. Failure to do so may result in sub-optimal behavior and exhausting connections in the connection pool. The unmarshalled response object can be obtained via ResponseInputStream.response(). The service documentation for the response content is as follows '

And:

> Note about the Apache http client: This input stream can be used to leverage a feature of the Apache http client where connections are released back to the connection pool to be reused. As such, calling close on this input stream will result in reading the remaining data from the stream and leaving the connection open, even if the stream was only partially read from. For large http payload, this means reading all of the http body before releasing the connection which may add latency.

[1]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/services/s3/S3Client.html#getObject(software.amazon.awssdk.services.s3.model.GetObjectRequest)
[2]: https://sdk.amazonaws.com/java/api/latest/software/amazon/awssdk/core/ResponseInputStream.html